### PR TITLE
refs #15 Issue: obj info type sprite breaks the current logic

### DIFF
--- a/addons/import_scml/import_plugin.gd
+++ b/addons/import_scml/import_plugin.gd
@@ -58,10 +58,14 @@ class SCMLObjectInfo:
 	var height : float
 
 	func from_attributes(attributes: Dictionary):
-		self.name = attributes["name"]
+		var name = attributes.get("realname")
+		if name == null:
+			name = attributes["name"]
+		self.name = name
 		self.type = attributes["type"]
-		self.width = float(attributes["w"])
-		self.height = float(attributes["h"])
+		if self.type == "bone":
+			self.width = float(attributes["w"])
+			self.height = float(attributes["h"])
 
 
 const SCML_NO_PARENT = -1
@@ -374,6 +378,14 @@ func _parse_data(path: String) -> SCMLData:
 				"obj_info":
 					assert(parents.size() == 2)
 					item = last_parent.add_object_info(attributes)
+				"frames":
+					# ignore i/frames when they appear in obj_info
+					item = 1
+					assert(parents.size() == 3)
+				"i":
+					# ignore i/frames when they appear in obj_info
+					item = 1
+					assert(parents.size() == 4)
 				"animation":
 					assert(parents.size() == 2)
 					item = last_parent.add_animation(attributes)


### PR DESCRIPTION
Issue: obj info type sprite breaks the current logic

Solution:
 * ignore its contents for now since it seems
 we actually only care about the contents for bones
 * when realname is present use realname instead of name for obj info
   since it seems that is what is later used in the scml file

refs #15