### PR TITLE
Fixes for bone scale, speed issues, incorrect animation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ hopefully empower other godot users with the ability to use it.
 	 * 4.3 (0.9.2)
  * Spriter SCML generator versions
 	 * r11
+
+> [!TIP]
+> When upgrading to 0.9.2 you might need to manually adjust/reset your import settings on any scml files you already have in your project.
+> The main difference/change is the playback speed needs to be set to 1 instead of 3 in order to have the animation speed match
+> the animation speed that was originally expected.
  
 # Known limitations
 
@@ -42,6 +47,7 @@ hopefully empower other godot users with the ability to use it.
  * fix optimisation logic that would incorrectly remove the last keyframe from a chain of similar values leading to incorrect animations
  * adjust "leaf" bones to not attempt to automatically calculate length to avoid generating a warning on import
  * issue a warning if importing an SCML file that is not generated with "r11"
+ * fix animation speed issue - treat times as being in ms and set default playback speed on import to 1
 
 ### 0.9.1
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Godot SCML Importer
 
 Godot is an awesome engine. Anyone using it deserves to be able to use the excellent resource and tools that exist along-side it. 
-One of these is Spriter from BrashMonkey. I had access to a number of animated character that I wanted to use with Godot and
-I didn't want to need to recreate the animations that I already had. This is why I wrote this addon and have decided to share it.
+One of these is Spriter from BrashMonkey. I had access to a number of animated characters that I wanted to use with Godot and
+I didn't want to need to recreate the animations that I already had. This caused me to write this addon and share it so as to
+hopefully empower other godot users with the ability to use it.
 
 ## Usage
  * install plugin
@@ -15,6 +16,7 @@ I didn't want to need to recreate the animations that I already had. This is why
  * Godot
 	 * 3.1.1 (< 0.8.0)
 	 * 4.0, 4.1, 4.2 (0.9.1)
+	 * 4.3 (0.9.2)
  * Spriter SCML generator versions
 	 * r11
  
@@ -25,9 +27,21 @@ I didn't want to need to recreate the animations that I already had. This is why
  * eventline (not sure what use case these serve - haven't investigated)
  * object types other than bone and the regular object (sprites)
  * all interpolation is currently assumed to be linear - other interpolations aren't supported for values
- * looping values isn't interpreted
+ * character map support
+
+## Known implementation quirks
+ * Bone scale animations will not work as expected due to how the scale handling is implemented in the plugin. Currently not expected to change as not expecting it to be a common concern for users (at least not reported).
 
 # Changelog
+
+### 0.9.2
+
+ * support looping value to avoid looping animations that aren't meant to loop
+ * fix issue with negative y scale on bones - this was leading to incorrect placement of child nodes
+ * fix logic that was incorrectly adding keyframes using the mainline key times for the reference timeline key values
+ * fix optimisation logic that would incorrectly remove the last keyframe from a chain of similar values leading to incorrect animations
+ * adjust "leaf" bones to not attempt to automatically calculate length to avoid generating a warning on import
+ * issue a warning if importing an SCML file that is not generated with "r11"
 
 ### 0.9.1
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ hopefully empower other godot users with the ability to use it.
  * adjust "leaf" bones to not attempt to automatically calculate length to avoid generating a warning on import
  * issue a warning if importing an SCML file that is not generated with "r11"
  * fix animation speed issue - treat times as being in ms and set default playback speed on import to 1
+ * add support for adjust z-index as needed by animations
 
 ### 0.9.1
 

--- a/addons/import_scml/import_plugin.gd
+++ b/addons/import_scml/import_plugin.gd
@@ -289,6 +289,7 @@ class SCMLAnimation:
 	var id: int
 	var length: float
 	var interval: float
+	var looping: bool
 	var name: String
 	var mainline: SCMLMainline
 	var timelines : Dictionary
@@ -299,6 +300,7 @@ class SCMLAnimation:
 		self.length = float(attributes["length"]) / 100
 		self.interval = float(attributes["interval"]) / 100
 		self.name = attributes["name"]
+		self.looping = attributes.get("looping", true)
 		self.timelines = {}
 		self.eventlines = {}
 
@@ -977,7 +979,12 @@ func _process_path(path: String, options: Dictionary):
 			
 			for track_index in range(animation.get_track_count()):
 				animation.track_set_interpolation_type(track_index, Animation.INTERPOLATION_LINEAR)
-				animation.track_set_interpolation_loop_wrap(track_index, options.loop_wrap_interpolation)
+				if scml_animation.looping:
+					animation.loop_mode = Animation.LOOP_LINEAR
+					animation.track_set_interpolation_loop_wrap(track_index, options.loop_wrap_interpolation)
+				else:
+					animation.loop_mode = Animation.LOOP_NONE
+					animation.track_set_interpolation_loop_wrap(track_index, false)
 
 		if options.optimize_for_blends:
 			_optimize_animations_for_blends(entity._animation_player)
@@ -1042,7 +1049,7 @@ func _get_import_options(path, preset):
 						]),
 					}, {
 						"name": "loop_wrap_interpolation",
-						"default_value": false
+						"default_value": true
 					}, {
 						"name": "optimize_for_blends",
 						"default_value": true

--- a/addons/import_scml/import_plugin.gd
+++ b/addons/import_scml/import_plugin.gd
@@ -658,9 +658,11 @@ class Entity:
 					var texture: Texture2D = self.get_animation_value(animation, String(node_path) + ':texture', instance.texture)
 					var offset: Vector2 = self.get_animation_value(animation, String(node_path) + ':offset', instance.offset)
 					var scale: Vector2 = self.get_animation_value(animation, String(node_path) + ':scale', instance.scale)
+					var z_index: int = self.get_animation_value(animation, String(node_path) + ':z_index', instance.z_index)
 					instance.texture = texture
 					instance.offset = offset
 					instance.scale = scale
+					instance.z_index = z_index
 
 	func build_path(scml_animation: SCMLAnimation, scml_mainline_key: SCMLMainlineKey, scml_reference: SCMLReference) -> Array:
 		var path_to_skeleton = []
@@ -927,14 +929,17 @@ func _process_path(path: String, options: Dictionary):
 						if angle_rad != null:
 							child.rotation = angle_rad
 
-						entity.add_animation_key(animation, String(node_path) + ':position', scml_mainline_key, scml_timeline_key.spin, position)
-						entity.add_animation_key(animation, String(node_path) + ':modulate', scml_mainline_key, scml_timeline_key.spin, modulate)
-						entity.add_animation_key(animation, String(node_path) + ':rotation', scml_mainline_key, scml_timeline_key.spin, angle_rad)
-						entity.add_animation_key(animation, String(node_path) + ':visible', scml_mainline_key, scml_timeline_key.spin, true)
+						if scml_mainline_key.time == scml_timeline_key.time:
+							entity.add_animation_key(animation, String(node_path) + ':position', scml_mainline_key, scml_timeline_key.spin, position)
+							entity.add_animation_key(animation, String(node_path) + ':modulate', scml_mainline_key, scml_timeline_key.spin, modulate)
+							entity.add_animation_key(animation, String(node_path) + ':rotation', scml_mainline_key, scml_timeline_key.spin, angle_rad)
+							entity.add_animation_key(animation, String(node_path) + ':visible', scml_mainline_key, scml_timeline_key.spin, true)
+
 						if child is Sprite2D:
-							entity.add_animation_key(animation, String(node_path) + ':texture', scml_mainline_key, scml_timeline_key.spin, texture)
-							entity.add_animation_key(animation, String(node_path) + ':offset', scml_mainline_key, scml_timeline_key.spin, offset)
-							entity.add_animation_key(animation, String(node_path) + ':scale', scml_mainline_key, scml_timeline_key.spin, scale)
+							if scml_mainline_key.time == scml_timeline_key.time:
+								entity.add_animation_key(animation, String(node_path) + ':texture', scml_mainline_key, scml_timeline_key.spin, texture)
+								entity.add_animation_key(animation, String(node_path) + ':offset', scml_mainline_key, scml_timeline_key.spin, offset)
+								entity.add_animation_key(animation, String(node_path) + ':scale', scml_mainline_key, scml_timeline_key.spin, scale)
 							entity.add_animation_key(animation, String(node_path) + ':z_index', scml_mainline_key, scml_timeline_key.spin, scml_reference.z_index)
 
 				for node_path in node_paths_missing.keys():

--- a/addons/import_scml/import_plugin.gd
+++ b/addons/import_scml/import_plugin.gd
@@ -495,6 +495,9 @@ func _optimize_animations_for_blends(animation_player: AnimationPlayer):
 			if not is_rotation:
 				continue
 
+			if animation.track_get_key_count(track_index) == 0:
+				continue
+
 			var value = animation.track_get_key_value(track_index, 0)
 			var diff = int(value / TAU) * TAU
 
@@ -866,6 +869,7 @@ func _process_path(path: String, options: Dictionary):
 						entity.ensure_track_exists(animation, String(node_path) + ':texture')
 						entity.ensure_track_exists(animation, String(node_path) + ':offset')
 						entity.ensure_track_exists(animation, String(node_path) + ':scale')
+						entity.ensure_track_exists(animation, String(node_path) + ':z_index')
 
 			for scml_mainline_key_t in scml_animation.mainline.children:
 				var scml_mainline_key: SCMLMainlineKey = scml_mainline_key_t
@@ -899,8 +903,12 @@ func _process_path(path: String, options: Dictionary):
 						var texture = null
 						child.position = position
 						if child is Bone2D and scml_child is SCMLBone:
+							if scale.y < 0:
+								child.scale = Vector2(1, -1)
+								scale = Vector2(scale.x, -scale.y)
+							else:
+								child.scale = Vector2.ONE
 							entity._scales[child] = scale
-							child.scale = Vector2.ONE
 						else:
 							var scml_file = parsed_data.folders[scml_child.folder].files[scml_child.file]
 							var pivot_x = scml_child.pivot_x if scml_child.pivot_x != null else scml_file.pivot_x
@@ -927,6 +935,7 @@ func _process_path(path: String, options: Dictionary):
 							entity.add_animation_key(animation, String(node_path) + ':texture', scml_mainline_key, scml_timeline_key.spin, texture)
 							entity.add_animation_key(animation, String(node_path) + ':offset', scml_mainline_key, scml_timeline_key.spin, offset)
 							entity.add_animation_key(animation, String(node_path) + ':scale', scml_mainline_key, scml_timeline_key.spin, scale)
+							entity.add_animation_key(animation, String(node_path) + ':z_index', scml_mainline_key, scml_timeline_key.spin, scml_reference.z_index)
 
 				for node_path in node_paths_missing.keys():
 					entity.add_animation_key(animation, String(node_path) + ':visible', scml_mainline_key, 0, false)
@@ -946,6 +955,7 @@ func _process_path(path: String, options: Dictionary):
 						entity.remove_if_track_empty(animation, String(node_path) + ':texture')
 						entity.remove_if_track_empty(animation, String(node_path) + ':offset')
 						entity.remove_if_track_empty(animation, String(node_path) + ':scale')
+						entity.remove_if_track_empty(animation, String(node_path) + ':z_index')
 					
 					for other_child in entity.get_instances_other(child_path):
 						var alt_path = entity.get_path_to_instance(other_child)

--- a/addons/import_scml/import_plugin.gd
+++ b/addons/import_scml/import_plugin.gd
@@ -1070,7 +1070,7 @@ func _get_import_options(path, preset):
 						"default_value": false
 					}, {
 						"name": "optimize_for_blends",
-						"default_value": false
+						"default_value": true
 					}, {
 						"name": "rest_pose_animation",
 						"default_value": ""

--- a/addons/import_scml/import_plugin.gd
+++ b/addons/import_scml/import_plugin.gd
@@ -111,7 +111,8 @@ class SCMLMainlineKey:
 
 	func from_attributes(attributes: Dictionary):
 		self.id = int(attributes["id"])
-		self.time = float(attributes.get("time", 0)) / 100
+		# time is in MS
+		self.time = float(attributes.get("time", 0)) / 1000
 		self.object_references = {}
 		self.bone_references = {}
 		self.children = []
@@ -220,7 +221,8 @@ class SCMLTimelineKey:
 	func from_attributes(attributes: Dictionary):
 		self.id = int(attributes["id"])
 		self.spin = int(attributes.get("spin", 0))
-		self.time = float(attributes.get("time", 0)) / 100
+		# Time is in ms
+		self.time = float(attributes.get("time", 0)) / 1000
 		self.objects = []
 		self.bones = []
 		self.children = []
@@ -297,8 +299,9 @@ class SCMLAnimation:
 
 	func from_attributes(attributes: Dictionary):
 		self.id = int(attributes["id"])
-		self.length = float(attributes["length"]) / 100
-		self.interval = float(attributes["interval"]) / 100
+		# time is in ms
+		self.length = float(attributes["length"]) / 1000
+		self.interval = float(attributes["interval"]) / 1000
 		self.name = attributes["name"]
 		self.looping = attributes.get("looping", true)
 		self.timelines = {}
@@ -482,8 +485,11 @@ func _optimize_animation(animation: Animation):
 			if current_transition == previous_transition and current_transition == following_transition \
 				and current_value == previous_value and current_value == following_value:
 				to_remove.append(key_index)
-		for key_index in to_remove:
-			animation.track_remove_key(track_index, key_index)
+			else:
+				to_remove.pop_front()
+				for remove_index in to_remove:
+					animation.track_remove_key(track_index, remove_index)
+				to_remove.clear()
 
 
 func _optimize_animations_for_blends(animation_player: AnimationPlayer):
@@ -1032,7 +1038,7 @@ func _get_import_options(path, preset):
 		Presets.DEFAULT:
 			return [{
 						"name": "playback_speed",
-						"default_value": 3,
+						"default_value": 1,
 						"property_hint": PROPERTY_HINT_RANGE,
 						"hint_string": "0,10,or_greater"
 					}, {

--- a/addons/import_scml/import_plugin.gd
+++ b/addons/import_scml/import_plugin.gd
@@ -408,7 +408,7 @@ func _parse_data(path: String) -> SCMLData:
 					item = parsed_data
 					var generator_version = attributes.get("generator_version")
 					if generator_version != "r11":
-						push_warning("SCML from non r11 version. May not work as expected. Found " + generator_version)
+						push_warning("SCML from non r11 version. May not work as expected. Try re-saving it with v11 spriter. Found " + generator_version)
 				"character_map":
 					item = SCMLParsedNode.new()
 				"map":

--- a/addons/import_scml/plugin.cfg
+++ b/addons/import_scml/plugin.cfg
@@ -3,5 +3,5 @@
 name="Import SCML"
 description="A plugin for importing SCML files as scenes in GODOT"
 author="Wojciech Michalak"
-version="0.9.1"
+version="0.9.2"
 script="import_scml.gd"


### PR DESCRIPTION
 * support looping value to avoid looping animations that aren't meant to loop
 * fix issue with negative y scale on bones - this was leading to incorrect placement of child nodes
 * fix logic that was incorrectly adding keyframes using the mainline key times for the reference timeline key values
 * fix optimisation logic that would incorrectly remove the last keyframe from a chain of similar values leading to incorrect animations
 * adjust "leaf" bones to not attempt to automatically calculate length to avoid generating a warning on import
 * issue a warning if importing an SCML file that is not generated with "r11"
 * fix animation speed issue - treat times as being in ms and set default playback speed on import to 1