### PR TITLE
Avoid failure to read "interval" from resulting in import failure

### DIFF
--- a/addons/import_scml/import_plugin.gd
+++ b/addons/import_scml/import_plugin.gd
@@ -302,7 +302,7 @@ class SCMLAnimation:
 		self.id = int(attributes["id"])
 		# time is in ms
 		self.length = float(attributes["length"]) / 1000
-		self.interval = float(attributes["interval"]) / 1000
+		self.interval = attributes.get("interval", 0.0) / 1000;
 		self.name = attributes["name"]
 		var looping_str = attributes.get("looping", "true")
 		self.looping = looping_str != "false"


### PR DESCRIPTION
Hello, thank you very much for your contribution to Godot. When I was trying to migrate the skeletal animations of Don't Starve to Godot, I discovered an issue: in the SCML files exported by older versions of Spriter, the "interval" entry may not exist in the animation's attributes. Therefore, to prevent the from_attributes method from failing when reading the "interval" key from the dictionary during animation import, a safer approach should be adopted to assign it a default value.

<img width="1346" height="176" alt="image" src="https://github.com/user-attachments/assets/8ce763bd-e747-42c9-b50e-20edd5303970" />
Here, the "interval" attribute does not exist in the animation tag, so parsing cannot proceed.